### PR TITLE
Add hook on BufRead

### DIFF
--- a/autoload/ctrlp/f.vim
+++ b/autoload/ctrlp/f.vim
@@ -26,8 +26,6 @@ function! ctrlp#f#init()
 endfunc
 
 function! ctrlp#f#accept(mode, str)
-  let cmd = 'fasd -A '.a:str
-  call system(cmd)
   call ctrlp#acceptfile(a:mode, a:str)
 endfunction
 

--- a/plugin/ctrlp-z.vim
+++ b/plugin/ctrlp-z.vim
@@ -1,2 +1,29 @@
 command! -n=* CtrlPZ cal ctrlp#init(ctrlp#z#id())
 command! -n=* CtrlPF cal ctrlp#init(ctrlp#f#id())
+
+" Put filename of bufnr into Fasd's database
+fu! s:record(bufnr)
+    if s:locked | retu | en
+    let bufnr = a:bufnr + 0
+    let bufname = bufname(bufnr)
+    if bufnr > 0 && !empty(bufname)
+        let fn = fnamemodify(bufname, ':p')
+        let fn = exists('+ssl') ? tr(fn, '/', '\') : fn
+        " Only normal file and normal buffer are recorded 
+        if !empty(getbufvar('^'.fn.'$', '&bt')) || !filereadable(fn)
+            retu
+        else
+            let cmd = 'fasd -A '.fn
+            call system(cmd)
+        en
+    en
+endf
+
+let s:locked = 0
+" Update Fasd database even when CtrlP's window is not awake
+aug CtrlPZ
+    au!
+    au BufRead * cal s:record(expand('<abuf>', 1))
+    au QuickFixCmdPre  *vimgrep* let s:locked = 1
+    au QuickFixCmdPost *vimgrep* let s:locked = 0
+aug END


### PR DESCRIPTION
- Update Fasd database independent of CtrlP's presence. Fasd accumulates correct
  information for file 'frecency' even when user invokes `:edit` to create/edit a file inside Vim.
- Only normal buffers are taken into consideration. _Example:_ Buffers invoked by `:help` command
  are neglected.
